### PR TITLE
Fix Amazon price caching

### DIFF
--- a/balkonkraftwerk-vergleich24/app/TableComponent.js
+++ b/balkonkraftwerk-vergleich24/app/TableComponent.js
@@ -60,15 +60,18 @@ export default function MaterialUITable() {
   const [cacheLoaded, setCacheLoaded] = useState(false);
 
   useEffect(() => {
-    fetch('/api/amazon/cache')
-      .then((res) => res.json())
-      .then((data) => {
+    async function loadCache() {
+      try {
+        const res = await fetch('/api/amazon/cache');
+        const data = await res.json();
         setPriceCache(data);
+      } catch {
+        // ignore errors, we will fallback to live fetches
+      } finally {
         setCacheLoaded(true);
-      })
-      .catch(() => {
-        setCacheLoaded(true);
-      });
+      }
+    }
+    loadCache();
   }, []);
 
 

--- a/balkonkraftwerk-vergleich24/app/TableComponent.js
+++ b/balkonkraftwerk-vergleich24/app/TableComponent.js
@@ -57,12 +57,18 @@ export default function MaterialUITable() {
   });
 
   const [priceCache, setPriceCache] = useState({});
+  const [cacheLoaded, setCacheLoaded] = useState(false);
 
   useEffect(() => {
     fetch('/api/amazon/cache')
       .then((res) => res.json())
-      .then((data) => setPriceCache(data))
-      .catch(() => {});
+      .then((data) => {
+        setPriceCache(data);
+        setCacheLoaded(true);
+      })
+      .catch(() => {
+        setCacheLoaded(true);
+      });
   }, []);
 
 
@@ -456,7 +462,7 @@ export default function MaterialUITable() {
                     </TableCell>)}
                       
                     <TableCell style={{ width: 150 }}>
-                      <AmazonPrice asin={row.asin} cached={priceCache[row.asin]} />
+                      <AmazonPrice asin={row.asin} cached={priceCache[row.asin]} cacheLoaded={cacheLoaded} />
                     </TableCell>
 
                     <TableCell>

--- a/balkonkraftwerk-vergleich24/app/TableComponent.js
+++ b/balkonkraftwerk-vergleich24/app/TableComponent.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from 'react';
 import Link from "next/link";
 import { 

--- a/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
+++ b/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
@@ -1,18 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 function AmazonPrice({ asin, cached, cacheLoaded }) {
     const [priceData, setPriceData] = useState(cached);
     const [error, setError] = useState(null);
+    const fetched = useRef(false);
 
     useEffect(() => {
       if (!asin || asin === "-") return;
+      if (fetched.current) return;
       if (!cacheLoaded) return;
       if (cached !== undefined) {
         setPriceData(cached);
+        fetched.current = true;
         return;
       }
+      fetched.current = true;
       console.log("Preisabfrage f\xC3\xBCr", asin);
       fetch(`/api/amazon?asin=${asin}`)
         .then((res) => res.json())

--- a/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
+++ b/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from "react";
 
-function AmazonPrice({ asin, cached }) {
+function AmazonPrice({ asin, cached, cacheLoaded }) {
     const [priceData, setPriceData] = useState(cached);
     const [error, setError] = useState(null);
 
     useEffect(() => {
       if (!asin || asin === "-") return;
-      if (cached) {
+      if (!cacheLoaded) return;
+      if (cached !== undefined) {
         setPriceData(cached);
         return;
       }
@@ -19,7 +20,7 @@ function AmazonPrice({ asin, cached }) {
           setPriceData(data);
         })
         .catch((err) => setError(err.message));
-    }, [asin, cached]);
+    }, [asin, cached, cacheLoaded]);
 
     if (!asin || asin === "-") {
         return <div>Preis manuell prüfen</div>;

--- a/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
+++ b/balkonkraftwerk-vergleich24/app/api/amazon/AmazonPrice.js
@@ -8,14 +8,16 @@ function AmazonPrice({ asin, cached, cacheLoaded }) {
     const fetched = useRef(false);
 
     useEffect(() => {
+      if (!cacheLoaded) return;
       if (!asin || asin === "-") return;
       if (fetched.current) return;
-      if (!cacheLoaded) return;
+
       if (cached !== undefined) {
         setPriceData(cached);
         fetched.current = true;
         return;
       }
+
       fetched.current = true;
       console.log("Preisabfrage f\xC3\xBCr", asin);
       fetch(`/api/amazon?asin=${asin}`)


### PR DESCRIPTION
## Summary
- fetch price cache once and delay rendering until loaded
- skip API calls until cache fetch is complete

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700419c64c832b82538ee2239eeffe