### PR TITLE
Add SEO about & FAQ pages with structured data

### DIFF
--- a/balkonkraftwerk-vergleich24/app/Header.js
+++ b/balkonkraftwerk-vergleich24/app/Header.js
@@ -11,8 +11,9 @@ import { motion } from "framer-motion";
 import Link from "@mui/material/Link";
 
 const pages = [
-  { name: "Balkon.Solar e.V.", url: "https://balkon.solar/" },
-  { name: "Dummylink", url: "#" }
+  { name: "Über uns", url: "/about" },
+  { name: "FAQ", url: "/faq" },
+  { name: "Balkon.Solar e.V.", url: "https://balkon.solar/" }
 ];
 
 const SUN_COUNT = 20;

--- a/balkonkraftwerk-vergleich24/app/PageLayout.js
+++ b/balkonkraftwerk-vergleich24/app/PageLayout.js
@@ -1,0 +1,49 @@
+"use client";
+import { useContext } from "react";
+import { DarkModeContext } from "./context/DarkModeContext";
+import Header from "./Header";
+import Footer from "./Footer";
+import styles from "./page.module.css";
+import { ThemeProvider, createTheme, CssBaseline } from "@mui/material";
+
+const lightTheme = createTheme({
+  palette: {
+    mode: "light",
+    background: {
+      default: "#F0F8FF",
+      paper: "#ffffff",
+    },
+    text: {
+      primary: "#000000",
+      secondary: "#555555",
+    },
+  },
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+    background: {
+      default: "#121212",
+      paper: "#1E1E1E",
+    },
+    text: {
+      primary: "#ffffff",
+      secondary: "#B3B3B3",
+    },
+  },
+});
+
+export default function PageLayout({ children }) {
+  const { isDarkMode, toggleDarkMode } = useContext(DarkModeContext);
+  return (
+    <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+      <CssBaseline />
+      <div className={styles.page}>
+        <Header isDarkMode={isDarkMode} toggleDarkMode={toggleDarkMode} />
+        <main className={styles.main}>{children}</main>
+        <Footer />
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/balkonkraftwerk-vergleich24/app/about/page.js
+++ b/balkonkraftwerk-vergleich24/app/about/page.js
@@ -2,6 +2,7 @@
 import { Container, Typography, Paper } from "@mui/material";
 import Head from "next/head";
 import { AboutJsonLd } from "../utils/aboutStructuredData";
+import PageLayout from "../PageLayout";
 
 export default function AboutPage() {
   return (
@@ -18,24 +19,26 @@ export default function AboutPage() {
         />
         <AboutJsonLd />
       </Head>
-      <Container maxWidth="md" sx={{ my: 4 }}>
-        <Paper sx={{ p: 4, boxShadow: 3 }}>
-          <Typography variant="h4" gutterBottom>
-            Über uns
-          </Typography>
-          <Typography variant="body1" gutterBottom>
-            Balkonspeicher24 wird von einem kleinen Team betrieben, das sich
-            leidenschaftlich mit Photovoltaik und Batteriespeichern beschäftigt.
-            Unser Ziel ist es, verständliche und unabhängige Informationen zu
-            liefern, damit jeder die passende Speicherlösung findet.
-          </Typography>
-          <Typography variant="body1" gutterBottom>
-            Die Inhalte basieren auf eigenen Erfahrungen sowie sorgfältiger
-            Recherche. Transparenz und Aktualität stehen dabei für uns im
-            Vordergrund.
-          </Typography>
-        </Paper>
-      </Container>
+      <PageLayout>
+        <Container maxWidth="md" sx={{ my: 4 }}>
+          <Paper sx={{ p: 4, boxShadow: 3 }}>
+            <Typography variant="h4" gutterBottom>
+              Über uns
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              Balkonspeicher24 wird von einem kleinen Team betrieben, das sich
+              leidenschaftlich mit Photovoltaik und Batteriespeichern beschäftigt.
+              Unser Ziel ist es, verständliche und unabhängige Informationen zu
+              liefern, damit jeder die passende Speicherlösung findet.
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              Die Inhalte basieren auf eigenen Erfahrungen sowie sorgfältiger
+              Recherche. Transparenz und Aktualität stehen dabei für uns im
+              Vordergrund.
+            </Typography>
+          </Paper>
+        </Container>
+      </PageLayout>
     </>
   );
 }

--- a/balkonkraftwerk-vergleich24/app/about/page.js
+++ b/balkonkraftwerk-vergleich24/app/about/page.js
@@ -1,0 +1,41 @@
+"use client";
+import { Container, Typography, Paper } from "@mui/material";
+import Head from "next/head";
+import { AboutJsonLd } from "../utils/aboutStructuredData";
+
+export default function AboutPage() {
+  return (
+    <>
+      <Head>
+        <title>Über uns | Balkonspeicher24</title>
+        <meta
+          name="description"
+          content="Lerne das Team hinter Balkonspeicher24 kennen."
+        />
+        <link
+          rel="canonical"
+          href="https://balkonspeicher24.shortaktien.de/about"
+        />
+        <AboutJsonLd />
+      </Head>
+      <Container maxWidth="md" sx={{ my: 4 }}>
+        <Paper sx={{ p: 4, boxShadow: 3 }}>
+          <Typography variant="h4" gutterBottom>
+            Über uns
+          </Typography>
+          <Typography variant="body1" gutterBottom>
+            Balkonspeicher24 wird von einem kleinen Team betrieben, das sich
+            leidenschaftlich mit Photovoltaik und Batteriespeichern beschäftigt.
+            Unser Ziel ist es, verständliche und unabhängige Informationen zu
+            liefern, damit jeder die passende Speicherlösung findet.
+          </Typography>
+          <Typography variant="body1" gutterBottom>
+            Die Inhalte basieren auf eigenen Erfahrungen sowie sorgfältiger
+            Recherche. Transparenz und Aktualität stehen dabei für uns im
+            Vordergrund.
+          </Typography>
+        </Paper>
+      </Container>
+    </>
+  );
+}

--- a/balkonkraftwerk-vergleich24/app/faq/page.js
+++ b/balkonkraftwerk-vergleich24/app/faq/page.js
@@ -10,6 +10,7 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Head from "next/head";
 import { FaqJsonLd } from "../utils/faqStructuredData";
+import PageLayout from "../PageLayout";
 
 const faqs = [
   {
@@ -41,23 +42,25 @@ export default function FaqPage() {
         <link rel="canonical" href="https://balkonspeicher24.shortaktien.de/faq" />
         <FaqJsonLd faqs={faqs} />
       </Head>
-      <Container maxWidth="md" sx={{ my: 4 }}>
-        <Paper sx={{ p: 4, boxShadow: 3 }}>
-          <Typography variant="h4" gutterBottom>
-            Häufige Fragen (FAQ)
-          </Typography>
-          {faqs.map((faq, index) => (
-            <Accordion key={index}>
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="subtitle1">{faq.question}</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Typography variant="body1">{faq.answer}</Typography>
-              </AccordionDetails>
-            </Accordion>
-          ))}
-        </Paper>
-      </Container>
+      <PageLayout>
+        <Container maxWidth="md" sx={{ my: 4 }}>
+          <Paper sx={{ p: 4, boxShadow: 3 }}>
+            <Typography variant="h4" gutterBottom>
+              Häufige Fragen (FAQ)
+            </Typography>
+            {faqs.map((faq, index) => (
+              <Accordion key={index}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle1">{faq.question}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography variant="body1">{faq.answer}</Typography>
+                </AccordionDetails>
+              </Accordion>
+            ))}
+          </Paper>
+        </Container>
+      </PageLayout>
     </>
   );
 }

--- a/balkonkraftwerk-vergleich24/app/faq/page.js
+++ b/balkonkraftwerk-vergleich24/app/faq/page.js
@@ -1,0 +1,63 @@
+"use client";
+import {
+  Container,
+  Typography,
+  Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Head from "next/head";
+import { FaqJsonLd } from "../utils/faqStructuredData";
+
+const faqs = [
+  {
+    question: "Was ist ein Balkonkraftwerk Speicher?",
+    answer:
+      "Ein Balkonkraftwerk Speicher ermöglicht es, überschüssigen Solarstrom zu speichern und später zu nutzen.",
+  },
+  {
+    question: "Brauche ich einen Wechselrichter?",
+    answer:
+      "Ja, ein Wechselrichter wandelt den erzeugten Gleichstrom in nutzbaren Wechselstrom um.",
+  },
+  {
+    question: "Lohnt sich ein Speicher finanziell?",
+    answer:
+      "Langfristig kann ein Speicher den Eigenverbrauch erhöhen und so Stromkosten senken.",
+  },
+];
+
+export default function FaqPage() {
+  return (
+    <>
+      <Head>
+        <title>FAQ | Balkonspeicher24</title>
+        <meta
+          name="description"
+          content="Antworten auf häufige Fragen zu Balkonkraftwerk Speichern."
+        />
+        <link rel="canonical" href="https://balkonspeicher24.shortaktien.de/faq" />
+        <FaqJsonLd faqs={faqs} />
+      </Head>
+      <Container maxWidth="md" sx={{ my: 4 }}>
+        <Paper sx={{ p: 4, boxShadow: 3 }}>
+          <Typography variant="h4" gutterBottom>
+            Häufige Fragen (FAQ)
+          </Typography>
+          {faqs.map((faq, index) => (
+            <Accordion key={index}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle1">{faq.question}</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Typography variant="body1">{faq.answer}</Typography>
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Paper>
+      </Container>
+    </>
+  );
+}

--- a/balkonkraftwerk-vergleich24/app/layout.js
+++ b/balkonkraftwerk-vergleich24/app/layout.js
@@ -82,6 +82,7 @@ export default function RootLayout({ children }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
         <meta name="author" content="Balkonspeicher Vergleich 24" />
+        <link rel="canonical" href="https://balkonspeicher24.shortaktien.de" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
 
@@ -109,6 +110,21 @@ export default function RootLayout({ children }) {
           type="application/ld+json"
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+
+        <Script
+          id="org-data"
+          type="application/ld+json"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              "name": "Balkonspeicher24",
+              "url": "https://balkonspeicher24.shortaktien.de",
+              "logo": "https://balkonspeicher24.shortaktien.de/logo.png"
+            })
+          }}
         />
 
         {/* Wenn du externe CSS-Dateien brauchst, importiere sie lieber global oder nutze ein CSS-in-JS-Lösung */}

--- a/balkonkraftwerk-vergleich24/app/page.js
+++ b/balkonkraftwerk-vergleich24/app/page.js
@@ -65,6 +65,7 @@ export default function Home() {
   return (
     <>
     <Head>
+      <link rel="canonical" href="https://balkonspeicher24.shortaktien.de" />
       <HomeJsonLd />
     </Head>
 

--- a/balkonkraftwerk-vergleich24/app/utils/aboutStructuredData.js
+++ b/balkonkraftwerk-vergleich24/app/utils/aboutStructuredData.js
@@ -1,0 +1,31 @@
+export function generateAboutJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "name": "Über uns",
+    "url": "https://balkonspeicher24.shortaktien.de/about",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Balkonspeicher24",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://balkonspeicher24.shortaktien.de/logo.png"
+      }
+    },
+    "about": {
+      "@type": "Organization",
+      "name": "Balkonspeicher24",
+      "description": "Wir sind Enthusiasten rund um Photovoltaik und Batteriespeicher und teilen unser Wissen auf dieser Seite."
+    }
+  };
+}
+
+export function AboutJsonLd() {
+  const jsonLd = generateAboutJsonLd();
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 2) }}
+    />
+  );
+}

--- a/balkonkraftwerk-vergleich24/app/utils/faqStructuredData.js
+++ b/balkonkraftwerk-vergleich24/app/utils/faqStructuredData.js
@@ -1,0 +1,24 @@
+export function generateFaqJsonLd(faqs) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": faqs.map((faq) => ({
+      "@type": "Question",
+      "name": faq.question,
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": faq.answer,
+      },
+    })),
+  };
+}
+
+export function FaqJsonLd({ faqs }) {
+  const jsonLd = generateFaqJsonLd(faqs);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 2) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add canonical link and organization JSON-LD in layout
- set canonical link on home page
- provide new `Über uns` page with author info
- add FAQ page with accordions
- include JSON-LD utilities for about and FAQ pages
- update header navigation

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6870c37b92fc832bb968d1d869accd55