### PR TITLE
Fix robots.txt and reduce polyfills

### DIFF
--- a/balkonkraftwerk-vergleich24/.browserslistrc
+++ b/balkonkraftwerk-vergleich24/.browserslistrc
@@ -1,0 +1,6 @@
+last 2 chrome versions
+last 2 firefox versions
+last 2 edge versions
+last 2 safari versions
+not dead
+

--- a/balkonkraftwerk-vergleich24/app/api/amazon/cache/route.js
+++ b/balkonkraftwerk-vergleich24/app/api/amazon/cache/route.js
@@ -13,7 +13,10 @@ export async function GET() {
   } catch (err) {
     return new Response(
       JSON.stringify({ error: "Cache not found" }),
-      { status: 500 }
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }
     );
   }
 }

--- a/balkonkraftwerk-vergleich24/app/layout.js
+++ b/balkonkraftwerk-vergleich24/app/layout.js
@@ -8,11 +8,13 @@ import products from "./products.json";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 // 🟢 **Generiere JSON-LD für strukturierte Daten**

--- a/balkonkraftwerk-vergleich24/public/robots.txt
+++ b/balkonkraftwerk-vergleich24/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+Disallow: /server/
+Disallow: /_next/
+Disallow: /private/
+Disallow: /hidden/
+
+Sitemap: https://balkonspeicher24.shortaktien.de/sitemap.xml


### PR DESCRIPTION
## Summary
- supply a static `robots.txt`
- add browserslist config for modern browsers
- allow fonts to load without blocking
- return 404 for missing Amazon cache instead of 500

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713817b2cc832b99499e1bec9b66eb